### PR TITLE
Fix has_extra return

### DIFF
--- a/custom_components/ecoflow/ecoflow/__init__.py
+++ b/custom_components/ecoflow/ecoflow/__init__.py
@@ -43,6 +43,7 @@ def get_model_name(product: int, model: int):
 def has_extra(product: int, model: int):
     if product in [5, 12]:
         return model == 2
+    return False
 
 
 def has_light(product: int):


### PR DESCRIPTION
FIX #7

## Cause 
In DELTA series, `has_extra` function returns None and the following conditional expression is always executed.
```py
if self.__extra_connected != ef.has_extra(self.product, data.get("model", None)):
    self.__extra_connected = not self.__extra_connected
```